### PR TITLE
client: make dart:io import more selective

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -1,5 +1,5 @@
 import 'dart:convert';
-import 'dart:io';
+import 'dart:io' show Cookie, HttpHeaders;
 
 import 'package:http/http.dart' as http;
 import 'package:iban/iban.dart';


### PR DESCRIPTION
In general, the dart:io library cannot be used in browser-based applications, c.f. https://api.dartlang.org/stable/2.4.0/dart-io/dart-io-library.html

Therefore, it's better to explicitly select which classes are used to avoid accidental introduction of incompatible classes.