### PR TITLE
client: send request via browser for web platform

### DIFF
--- a/lib/src/browser_client.dart
+++ b/lib/src/browser_client.dart
@@ -1,0 +1,9 @@
+import "package:http/browser_client.dart";
+
+// By calling this class 'Client' it becomes interchangeable
+// with the Client class from package:http/http.dart.
+class Client extends BrowserClient {
+  Client() {
+    withCredentials = true;
+  }
+}

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -1,9 +1,10 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:http/http.dart' as http;
+import 'package:http/http.dart' show Response;
 import 'package:iban/iban.dart';
 
+import 'package:http/http.dart' if (dart.library.js) 'browser_client.dart' as http;
 import 'exceptions.dart';
 import 'order.dart';
 import 'owner.dart';
@@ -202,7 +203,7 @@ class Client {
     throw FailedHttpRequest(Uri.parse(requestUrl), '', response);
   }
 
-  void _setSession(http.Response response) {
+  void _setSession(Response response) {
     String cookie = response.headers[HttpHeaders.setCookieHeader];
     if (cookie != null) {
       _session = Cookie.fromSetCookieValue(cookie);


### PR DESCRIPTION
Due to CORS policies cookie handling is forbidden in the browser. Therefore, let the browser handle the session cookies by using `package:http/browser_client.dart`.

Due to conditional imports the HTTP client from `package:http/http.dart` remains being used when run inside the dart VM.

This could be further cleaned up by isolating the cookie handling for the VM case only. Currently, this causes warnings to be printed in the browser console but otherwise works fine.