### PR TITLE
[WIP] client: pass response instead of exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ dependencies:
 
 ## Licence overview
 
-All files in this repository fall under the license specified in 
+All files in this repository fall under the license specified in
 [COPYING](COPYING). The project is licensed as [AGPL with a lesser clause](https://www.gnu.org/licenses/agpl-3.0.en.html). 
 It may be used within a proprietary project, but the core library and any 
 changes to it must be published online. Source code for this library must 


### PR DESCRIPTION
Dart exceptions turn into strings when they pass the javascript barrier. Hence, it's not possible to handle them in javascript. Therefore, just return the error response object.